### PR TITLE
Offer proguard consumer rules for downstream library consumers.

### DIFF
--- a/engine/consumer-rules.pro
+++ b/engine/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class dgca.verifier.app.** { *; }

--- a/engine/consumer-rules.pro
+++ b/engine/consumer-rules.pro
@@ -1,1 +1,4 @@
+# For upstream certlogic.kt as it does not have a consumer-rules mechanism (non Android project)
+-keep class eu.ehn.dcc.certlogic.** { *; }
+# See https://github.com/eu-digital-green-certificates/dgc-certlogic-android/pull/44
 -keep class dgca.verifier.app.** { *; }


### PR DESCRIPTION
Keep rule to prevent code shrinker from breaking validation.

Specifically, proguard/R8 removes values from `ExternalParameter` due to its private constructor:
https://github.com/eu-digital-green-certificates/dgc-certlogic-android/blob/b0c60505cc28e8fd42fa19c6792a911683c843b5/engine/src/main/java/dgca/verifier/app/engine/data/ExternalParameter.kt#L49-L58

```json
Without Proguard: {
    "external": {
        "validationClock": "2021-07-21T15:22:45Z",
        "valueSets": {...},
        "countryCode": "DE",
        "exp": "2022-07-21T07:05:48Z",
        "iat": "2021-07-21T07:05:48Z",
        "issuerCountryCode": "DE",
        "kid": "f1sfUVIx8CA=",
        "region": ""
    },
    "payload": {...}
}
```
vs

```json
Proguard: {
    "external": {
        "valueSets": {...}
    },
    "payload": {...}
}
```

Due to the way exceptions are caught, this resulted in a silent fail where a rule evaluation just defaulted to `OPEN`.
