### PR TITLE
Improve error handling by exposing exceptions instead of silently consuming them

### DIFF
--- a/engine/src/main/java/dgca/verifier/app/engine/DefaultCertLogicEngine.kt
+++ b/engine/src/main/java/dgca/verifier/app/engine/DefaultCertLogicEngine.kt
@@ -69,44 +69,64 @@ class DefaultCertLogicEngine(
     ): List<ValidationResult> {
         if (rules.isEmpty()) return emptyList()
 
-        val validationResults = mutableListOf<ValidationResult>()
         val dataJsonNode = prepareData(externalParameter, payload)
-        val hcertVersion = hcertVersionString.toVersion()
-        rules.forEach { rule ->
-            val ruleEngineVersion = rule.engineVersion.toVersion()
-            val schemaVersion = rule.schemaVersion.toVersion()
-            val res = when {
-                rule.engine == CERTLOGIC_KEY && ruleEngineVersion != null && CERTLOGIC_VERSION.isGreaterOrEqualThan(
-                    ruleEngineVersion
-                ) && hcertVersion != null && schemaVersion != null && hcertVersion.first == schemaVersion.first && hcertVersion.isGreaterOrEqualThan(
-                    schemaVersion
-                ) ->
-                    when (jsonLogicValidator.isDataValid(
-                        rule.logic,
-                        dataJsonNode
-                    )) {
-                        true -> Result.PASSED
-                        false -> Result.FAIL
-                        else -> Result.OPEN
-                    }
-                else -> Result.OPEN
-            }
-            val cur: String = affectedFieldsDataRetriever.getAffectedFieldsData(
-                rule,
-                dataJsonNode,
-                certificateType
-            )
-            validationResults.add(
-                ValidationResult(
-                    rule,
-                    res,
-                    cur,
-                    null
-                )
+        val hcertVersion: Triple<Int, Int, Int>? = hcertVersionString.toVersion()
+
+        return rules.map {
+            checkRule(
+                rule = it,
+                dataJsonNode = dataJsonNode,
+                hcertVersion = hcertVersion,
+                certificateType = certificateType
             )
         }
+    }
 
-        return validationResults
+    private fun checkRule(
+        rule: Rule,
+        dataJsonNode: ObjectNode,
+        hcertVersion: Triple<Int, Int, Int>?,
+        certificateType: CertificateType
+    ): ValidationResult {
+        val ruleEngineVersion = rule.engineVersion.toVersion()
+        val schemaVersion = rule.schemaVersion.toVersion()
+
+        val validationErrors = mutableListOf<Exception>()
+
+        val isCompatibleVersion = rule.engine == CERTLOGIC_KEY &&
+                ruleEngineVersion != null &&
+                CERTLOGIC_VERSION.isGreaterOrEqualThan(ruleEngineVersion) &&
+                hcertVersion != null &&
+                schemaVersion != null &&
+                hcertVersion.first == schemaVersion.first &&
+                hcertVersion.isGreaterOrEqualThan(schemaVersion)
+
+        val res = if (isCompatibleVersion) {
+            try {
+                when (jsonLogicValidator.isDataValid(rule.logic, dataJsonNode)) {
+                    true -> Result.PASSED
+                    false -> Result.FAIL
+                }
+            } catch (e: Exception) {
+                validationErrors.add(e)
+                Result.OPEN
+            }
+        } else {
+            Result.OPEN
+        }
+
+        val cur: String = affectedFieldsDataRetriever.getAffectedFieldsData(
+            rule,
+            dataJsonNode,
+            certificateType
+        )
+
+        return ValidationResult(
+            rule,
+            res,
+            cur,
+            if (validationErrors.isEmpty()) null else validationErrors
+        )
     }
 
     private fun Triple<Int, Int, Int>.isGreaterOrEqualThan(version: Triple<Int, Int, Int>): Boolean =

--- a/engine/src/main/java/dgca/verifier/app/engine/DefaultJsonLogicValidator.kt
+++ b/engine/src/main/java/dgca/verifier/app/engine/DefaultJsonLogicValidator.kt
@@ -26,10 +26,7 @@ import eu.ehn.dcc.certlogic.evaluate
  * Created by osarapulov on 13.06.21 17:20
  */
 class DefaultJsonLogicValidator : JsonLogicValidator {
-    override fun isDataValid(rule: JsonNode, data: JsonNode): Boolean? = try {
+    override fun isDataValid(rule: JsonNode, data: JsonNode): Boolean =
         (evaluate(rule, data) as BooleanNode).asBoolean()
-    } catch (error: Throwable) {
-        null
-    }
 
 }

--- a/engine/src/main/java/dgca/verifier/app/engine/JsonLogicValidator.kt
+++ b/engine/src/main/java/dgca/verifier/app/engine/JsonLogicValidator.kt
@@ -24,5 +24,5 @@ import com.fasterxml.jackson.databind.JsonNode
  * Created by osarapulov on 13.06.21 17:18
  */
 interface JsonLogicValidator {
-    fun isDataValid(rule: JsonNode, data: JsonNode): Boolean?
+    fun isDataValid(rule: JsonNode, data: JsonNode): Boolean
 }

--- a/engine/src/main/java/dgca/verifier/app/engine/ValidationResult.kt
+++ b/engine/src/main/java/dgca/verifier/app/engine/ValidationResult.kt
@@ -31,5 +31,5 @@ class ValidationResult(
     val rule: Rule,
     val result: Result,
     val current: String,
-    val validationErrors: List<Throwable>?,
+    val validationErrors: List<Exception>?,
 )

--- a/engine/src/test/java/dgca/verifier/app/engine/DefaultCertLogicEngineTest.kt
+++ b/engine/src/test/java/dgca/verifier/app/engine/DefaultCertLogicEngineTest.kt
@@ -36,6 +36,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import java.io.InputStream
 import java.nio.charset.Charset
 import java.time.ZonedDateTime
@@ -240,7 +241,7 @@ internal class DefaultCertLogicEngineTest {
 
     @Test
     fun testValidatedWithException() {
-        doReturn(null).`when`(jsonLogicValidator).isDataValid(any(), any())
+        doThrow(RuntimeException()).`when`(jsonLogicValidator).isDataValid(any(), any())
         val hcertJson = mockHcertJson()
         val rules = listOf(mockRuleRemote()).toRules()
         val externalParameter = mockExternalParameter()

--- a/engine/src/test/java/dgca/verifier/app/engine/DefaultJsonLogicValidatorTest.kt
+++ b/engine/src/test/java/dgca/verifier/app/engine/DefaultJsonLogicValidatorTest.kt
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Assertions.*
 class DefaultJsonLogicValidatorTest {
  private val jsonLogicValidator = DefaultJsonLogicValidator()
 
-    @Test
+    @Test(expected = RuntimeException::class)
     fun testException() {
         assertNull(jsonLogicValidator.isDataValid(jacksonObjectMapper().readValue("{}"), jacksonObjectMapper().readValue("{}")))
     }


### PR DESCRIPTION
This is a follow up to #44
Debugging was really difficult because there was no visible error.
`ValidationResult` already has a field to return errors that we can use, it was just set to `null`.

This PR:

* Catch `Exception` not `Throwable` as the libraries should not quietly contain an `Error` being thrown.
* Catch `Exception` map it to `OPEN` but save the exception and fill the validation result with any errors, otherwise set it to null.
* Refactored the code a bit as it was really really really difficult to read. :heart: 

The library should behave exactly the same to the outside, except that if there is an internal `Exception` being thrown, then `ValidationResult.validationErrors` is not `null`.
