### PR TITLE
Fix format of validation clock

### DIFF
--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -25,6 +25,8 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
+
         sourceCompatibility Config.javaVersion
         targetCompatibility Config.javaVersion
     }
@@ -43,7 +45,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_reflect
     implementation Deps.kotlinx_coroutines_core

--- a/engine/src/main/java/dgca/verifier/app/engine/data/ExternalParameter.kt
+++ b/engine/src/main/java/dgca/verifier/app/engine/data/ExternalParameter.kt
@@ -66,7 +66,7 @@ class ExternalParameter private constructor(
         kid: String,
         region: String = ""
     ) : this(
-        validationClock = DateTimeFormatter.ISO_ZONED_DATE_TIME.format(validationClock),
+        validationClock = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(validationClock),
         valueSets = valueSets,
         countryCode = countryCode,
         exp = exp.toString(),


### PR DESCRIPTION
The current format of the validationClock in ExtermalParameter uses DateTimeFormatter.ISO_ZONED_DATE_TIME which includes a region information in square brackets. This leads to a DateTimeParseException (in DefaultCertLogicEngine.kt:111) when evaluating any rules that reference the validationClock.